### PR TITLE
Add MATLAB SPGD controller with simulation and Red Pitaya support

### DIFF
--- a/matlab/README.md
+++ b/matlab/README.md
@@ -41,12 +41,23 @@ Important optional parameters include:
   threshold.
 * `ControlLimits` – saturation limits (in volts) applied to the control output,
   matching the ±1 V range of the Red Pitaya DAC by default.
+* `MeasurementSmoothFactor` – exponential smoothing factor (0–1) used to
+  average the detector readings that drive the controller; set to 0 to disable
+  smoothing.
+* `GradientSmoothFactor` – smoothing factor (0–1) applied to the estimated
+  gradient to tame stochastic fluctuations.
+* `MinPerturbationRatio` / `MinGainRatio` – floors that limit how much the SPGD
+  dither amplitude and gain shrink when efficiency exceeds the threshold.  This
+  adaptive scaling keeps the lock tight while preventing excessive dithering
+  once the optimum has been located.
 * `SimulationPlant` – struct overriding the built-in simulation model.
 
 The live figure shows:
 
-1. Measured intensity versus time, including the best-achieved peak trace and
-   the adaptive reference intensity used to enforce the efficiency threshold.
+1. Measured intensity versus time, showing the smoothed detector signal used by
+   the controller together with the raw samples, the best-achieved peak trace,
+   and the adaptive reference intensity used to enforce the efficiency
+   threshold.
 2. Tracking error relative to the target intensity.
 3. Single-sided intensity noise spectrum (dBc/Hz, logarithmic frequency axis)
    computed using Welch's method.
@@ -54,10 +65,13 @@ The live figure shows:
    axis), so you can confirm the actuator stays near the optimal command while
    preserving the required efficiency margin.
 
-The controller continuously monitors the detector efficiency.  If the measured
-intensity ever falls below the configurable threshold (95% by default) it
-restores the best-known actuator value and re-measures until the efficiency
-recovers, or gradually relaxes the reference level if the plant dynamics shift.
+The controller continuously monitors the detector efficiency, using the
+smoothed detector signal against the decayed best-achieved intensity.  If the
+efficiency drops below the configurable threshold (95% by default) it restores
+the best-known actuator value and re-measures until the efficiency recovers, or
+gradually relaxes the reference level if the plant dynamics shift.  When the
+loop is stably locked, the adaptive perturbation/gain scaling suppresses
+residual dithering so the detector power and error traces stay quiet.
 
 ## Hardware Notes
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -26,18 +26,38 @@ Important optional parameters include:
   amplitude.
 * `Iterations` – number of iterations to execute.
 * `Target` – desired intensity set-point.
+* `EfficiencyThreshold` – minimum acceptable ratio of current intensity to the
+  best recorded intensity (default 0.95).  When the efficiency drops below this
+  limit the controller automatically restores the best-known actuator command to
+  keep the detector near its maximum.
+* `BestDecayRate` – fractional decay applied to the stored reference intensity
+  when no new maximum is observed (prevents stale peaks from dominating the
+  efficiency estimate).
 * `SampleRate` – sampling rate used for the real-time PSD estimate.
 * `SampleHoldTime` – dwell time after each output update before acquiring a
   sample (useful when the plant needs time to settle).
+* `RestoreMaxAttempts` – number of consecutive measurements allowed while
+  recovering the best-known control point when efficiency dips below the
+  threshold.
+* `ControlLimits` – saturation limits (in volts) applied to the control output,
+  matching the ±1 V range of the Red Pitaya DAC by default.
 * `SimulationPlant` – struct overriding the built-in simulation model.
 
 The live figure shows:
 
-1. Measured intensity versus time.
+1. Measured intensity versus time, including the best-achieved peak trace and
+   the adaptive reference intensity used to enforce the efficiency threshold.
 2. Tracking error relative to the target intensity.
 3. Single-sided intensity noise spectrum (dBc/Hz, logarithmic frequency axis)
    computed using Welch's method.
-4. Control output applied to the actuator.
+4. Combined plot showing efficiency (left axis) and control output (right
+   axis), so you can confirm the actuator stays near the optimal command while
+   preserving the required efficiency margin.
+
+The controller continuously monitors the detector efficiency.  If the measured
+intensity ever falls below the configurable threshold (95% by default) it
+restores the best-known actuator value and re-measures until the efficiency
+recovers, or gradually relaxes the reference level if the plant dynamics shift.
 
 ## Hardware Notes
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -1,0 +1,74 @@
+# MATLAB SPGD Control Script
+
+This directory contains the `spgd_control.m` utility that can run a
+simultaneous perturbation stochastic gradient descent (SPGD) lock either in
+simulation or against a Red Pitaya board through its SCPI interface.
+
+## Requirements
+
+* MATLAB R2020a or newer (for `tcpclient`, `tiledlayout`, `semilogx`, and
+  `pwelch`).
+* Instrument Control Toolbox for hardware mode (provides the TCP/IP client).
+
+## Usage
+
+Add this folder to the MATLAB path and call `spgd_control`.
+
+```matlab
+addpath('path/to/matlab');
+spgd_control();                     % run the default simulation
+spgd_control('Mode','hardware');    % connect to 192.168.10.2:5000 via SCPI
+```
+
+Important optional parameters include:
+
+* `Gain` and `Perturbation` – tune the SPGD gradient step and perturbation
+  amplitude.
+* `Iterations` – number of iterations to execute.
+* `Target` – desired intensity set-point.
+* `SampleRate` – sampling rate used for the real-time PSD estimate.
+* `SampleHoldTime` – dwell time after each output update before acquiring a
+  sample (useful when the plant needs time to settle).
+* `SimulationPlant` – struct overriding the built-in simulation model.
+
+The live figure shows:
+
+1. Measured intensity versus time.
+2. Tracking error relative to the target intensity.
+3. Single-sided intensity noise spectrum (dBc/Hz, logarithmic frequency axis)
+   computed using Welch's method.
+4. Control output applied to the actuator.
+
+## Hardware Notes
+
+* The script assumes the plant signal is present on Red Pitaya ADC channel 1
+  and the actuator is driven via DAC channel 1.
+* The default SCPI endpoint is `192.168.10.2:5000`; adjust using the
+  `RedPitayaHost` and `RedPitayaPort` parameters.
+* Ensure that the board is already configured in LV mode and that the
+  necessary analog front-end connections are in place.
+* The ADC query parsing logic expects responses in the default ASCII vector
+  format (e.g. `{0.01,0.02,...}`).  If your firmware outputs a different
+  format, adapt the `parse_red_pitaya_vector` helper inside the script.
+
+## Simulation Model
+
+The built-in simulation backend implements a first-order plant with a sine-wave
+ disturbance and additive Gaussian noise.  Override any of the following fields
+via the `SimulationPlant` parameter:
+
+* `Gain`
+* `TimeConstant`
+* `DisturbanceAmplitude`
+* `DisturbanceFrequency`
+* `DisturbancePhase`
+* `NoiseStd`
+* `Offset`
+* `InitialState`
+
+Example with a slower plant:
+
+```matlab
+params = struct('TimeConstant', 5e-3, 'Gain', 1.2);
+spgd_control('SimulationPlant', params, 'Iterations', 3000);
+```

--- a/matlab/spgd_control.m
+++ b/matlab/spgd_control.m
@@ -1,0 +1,377 @@
+function spgd_control(varargin)
+%SPGD_CONTROL Run an SPGD control loop in simulation or with a Red Pitaya.
+%   SPGD_CONTROL() runs a default simulation of a single-actuator SPGD loop
+%   and plots the input signal, error, intensity noise spectrum (in dBc/Hz)
+%   with a logarithmic frequency axis, and the control output.
+%
+%   SPGD_CONTROL('Mode','hardware') connects to a Red Pitaya at the
+%   configured IP address (default 192.168.10.2:5000) via SCPI and locks a
+%   single channel using simultaneous perturbation stochastic gradient
+%   descent.  The script assumes the fast ADC channel 1 provides the
+%   intensity signal and the fast DAC channel 1 drives the actuator.
+%
+%   Optional name/value arguments:
+%       'Mode'              - "simulation" (default) or "hardware"
+%       'Iterations'        - Number of SPGD iterations (default 2000)
+%       'SampleRate'        - Sampling rate used for PSD estimation (Hz)
+%                             (default 20000)
+%       'Gain'              - SPGD gain coefficient (default 0.08)
+%       'Perturbation'      - Perturbation amplitude applied to the
+%                             actuator during gradient estimation (default
+%                             0.05)
+%       'Target'            - Desired normalized intensity (default 1.0)
+%       'NumActuators'      - Number of control outputs (default 1)
+%       'PlotUpdateInterval'- Update plots every N iterations (default 10)
+%       'RedPitayaHost'     - Hostname or IP of the Red Pitaya
+%                             (default "192.168.10.2")
+%       'RedPitayaPort'     - SCPI port (default 5000)
+%       'Timeout'           - SCPI read/write timeout in seconds (default 2)
+%       'Seed'              - Random seed for reproducible perturbations
+%                             (default 1)
+%       'SimulationPlant'   - Struct overriding the default plant
+%                             parameters when running in simulation.  See
+%                             LOCAL_DEFAULT_SIM_PLANT() for details.
+%
+%   The function shows live plots of the input intensity, tracking error,
+%   single-sided intensity noise spectrum (dBc/Hz) and actuator command.
+%   The noise spectrum is computed using Welch's method and referenced to
+%   the squared target intensity.
+%
+%   Example (simulation):
+%       spgd_control('Iterations', 1500, 'Gain', 0.06, 'Perturbation', 0.02);
+%
+%   Example (hardware):
+%       spgd_control('Mode','hardware','Iterations',1200,'Gain',0.04);
+%
+%   NOTE: When running in hardware mode you must ensure that the Red Pitaya
+%   is configured to stream the desired analog input signal on ADC1 and that
+%   DAC1 is routed to your actuator.  The script configures the waveform
+%   generator to produce a DC output whose value is updated each iteration.
+%
+%   This script is intentionally self-contained so it can be dropped into a
+%   MATLAB path or executed directly from the repository.
+
+    opts = parse_inputs(varargin{:});
+    rng(opts.Seed); %#ok<RNG>
+
+    backend = create_backend(opts);
+    cleanupObj = onCleanup(@() backend.cleanup()); %#ok<NASGU>
+
+    nIter = opts.Iterations;
+    nActuators = opts.NumActuators;
+    control = zeros(nActuators, 1);
+    perturb = zeros(nActuators, 1);
+
+    intensityHistory = zeros(nIter, 1);
+    errorHistory = zeros(nIter, 1);
+    controlHistory = zeros(nIter, nActuators);
+    timeAxis = (0:nIter-1).' ./ opts.SampleRate;
+
+    [fig, plots] = create_plots(opts, timeAxis);
+
+    backend.apply(control);
+    pause(0.05); % allow the output to settle
+
+    for k = 1:nIter
+        perturb(:) = opts.Perturbation * (2 * randi([0, 1], nActuators, 1) - 1);
+
+        backend.apply(control + perturb);
+        pause(opts.SampleHoldTime);
+        yPlus = backend.measure();
+
+        backend.apply(control - perturb);
+        pause(opts.SampleHoldTime);
+        yMinus = backend.measure();
+
+        if ~all(isfinite([yPlus, yMinus]))
+            warning('Skipping iteration %d due to invalid measurements.', k);
+            controlHistory(k, :) = control;
+            if k > 1
+                intensityHistory(k) = intensityHistory(k-1);
+                errorHistory(k) = errorHistory(k-1);
+            else
+                intensityHistory(k) = NaN;
+                errorHistory(k) = NaN;
+            end
+            continue;
+        end
+
+        denom = 2 * perturb;
+        zeroMask = abs(denom) < eps;
+        denom(zeroMask) = eps .* sign(perturb(zeroMask) + (perturb(zeroMask) == 0));
+        denom(denom == 0) = eps;
+        gradient = (yPlus - yMinus) ./ denom;
+        control = control + opts.Gain * gradient;
+        backend.apply(control);
+
+        pause(opts.SampleHoldTime);
+        intensity = backend.measure();
+        if ~isfinite(intensity)
+            warning('Received invalid intensity measurement at iteration %d.', k);
+            if k > 1
+                intensity = intensityHistory(k-1);
+            else
+                intensity = opts.Target;
+            end
+        end
+        err = opts.Target - intensity;
+
+        intensityHistory(k) = intensity;
+        errorHistory(k) = err;
+        controlHistory(k, :) = control;
+
+        if mod(k, opts.PlotUpdateInterval) == 0 || k == nIter
+            update_plots(plots, intensityHistory, errorHistory, controlHistory, ...
+                timeAxis, opts, k);
+        end
+
+        if ~isvalid(fig)
+            warning('SPGD loop stopped because the figure window was closed.');
+            break;
+        end
+    end
+
+    backend.apply(control); % ensure actuator is left at last value
+    drawnow;
+
+    fprintf('\nSPGD completed %d iterations in %s mode. Final intensity %.4f, error %.4f.\n', ...
+        k, opts.Mode, intensityHistory(k), errorHistory(k));
+end
+
+function opts = parse_inputs(varargin)
+    p = inputParser;
+    p.FunctionName = 'spgd_control';
+    addParameter(p, 'Mode', "simulation", @(x) any(strcmpi(x, {"simulation", "hardware"})));
+    addParameter(p, 'Iterations', 2000, @(x) validateattributes(x, {'numeric'}, {'scalar', 'positive', 'integer'}));
+    addParameter(p, 'SampleRate', 20e3, @(x) validateattributes(x, {'numeric'}, {'scalar', 'positive'}));
+    addParameter(p, 'Gain', 0.08, @(x) validateattributes(x, {'numeric'}, {'scalar', 'real'}));
+    addParameter(p, 'Perturbation', 0.05, @(x) validateattributes(x, {'numeric'}, {'scalar', 'positive'}));
+    addParameter(p, 'Target', 1.0, @(x) validateattributes(x, {'numeric'}, {'scalar', 'real'}));
+    addParameter(p, 'NumActuators', 1, @(x) validateattributes(x, {'numeric'}, {'scalar', 'integer', '>=', 1}));
+    addParameter(p, 'PlotUpdateInterval', 10, @(x) validateattributes(x, {'numeric'}, {'scalar', 'integer', '>=', 1}));
+    addParameter(p, 'RedPitayaHost', "192.168.10.2", @(x) validateattributes(x, {'char', 'string'}, {'nonempty'}));
+    addParameter(p, 'RedPitayaPort', 5000, @(x) validateattributes(x, {'numeric'}, {'scalar', 'integer', 'positive'}));
+    addParameter(p, 'Timeout', 2.0, @(x) validateattributes(x, {'numeric'}, {'scalar', 'positive'}));
+    addParameter(p, 'Seed', 1, @(x) validateattributes(x, {'numeric'}, {'scalar', 'real'}));
+    addParameter(p, 'SimulationPlant', struct(), @(x) isstruct(x));
+    addParameter(p, 'SampleHoldTime', 1e-3, @(x) validateattributes(x, {'numeric'}, {'scalar', 'nonnegative'}));
+    parse(p, varargin{:});
+
+    opts = p.Results;
+    opts.Mode = lower(string(opts.Mode));
+    opts.RedPitayaHost = char(opts.RedPitayaHost);
+
+    if opts.NumActuators ~= 1
+        warning(['The provided SPGD implementation drives a single actuator. ', ...
+            'Additional actuators will share the same command value.']);
+    end
+
+    if opts.SampleHoldTime <= 0
+        opts.SampleHoldTime = 1 / max(opts.SampleRate, 1);
+    end
+
+    if strcmp(opts.Mode, "simulation")
+        opts.SimulationPlant = merge_struct(local_default_sim_plant(), opts.SimulationPlant);
+    end
+end
+
+function backend = create_backend(opts)
+    switch opts.Mode
+        case "hardware"
+            backend = create_red_pitaya_backend(opts);
+        otherwise
+            backend = create_simulation_backend(opts);
+    end
+end
+
+function backend = create_simulation_backend(opts)
+    plant = opts.SimulationPlant;
+    state.x = plant.InitialState;
+    state.t = 0;
+    backendState.control = zeros(opts.NumActuators, 1);
+
+    backend.apply = @apply_sim;
+    backend.measure = @measure_sim;
+    backend.cleanup = @() disp('Simulation backend shut down.');
+
+    function apply_sim(u)
+        backendState.control = u(:);
+    end
+
+    function intensity = measure_sim()
+        [intensity, state] = simulate_step(state, backendState.control, plant, opts);
+    end
+end
+
+function backend = create_red_pitaya_backend(opts)
+    try
+        client = tcpclient(opts.RedPitayaHost, opts.RedPitayaPort, 'Timeout', opts.Timeout);
+    catch err
+        error('Failed to connect to Red Pitaya at %s:%d (%s).', opts.RedPitayaHost, opts.RedPitayaPort, err.message);
+    end
+
+    configure_red_pitaya(client);
+
+    backend.apply = @(u) set_red_pitaya_output(client, u);
+    backend.measure = @() read_red_pitaya_adc(client);
+    backend.cleanup = @() cleanup_red_pitaya(client);
+end
+
+function configure_red_pitaya(client)
+    send_scpi(client, 'OUTPUT1:STATE OFF');
+    send_scpi(client, 'SOUR1:FUNC DC');
+    send_scpi(client, 'SOUR1:VOLT 0');
+    send_scpi(client, 'OUTPUT1:STATE ON');
+    send_scpi(client, 'ACQ:RST');
+    send_scpi(client, 'ACQ:DEC 1');
+    send_scpi(client, 'ACQ:TRIG:LEV 0');
+    send_scpi(client, 'ACQ:TRIG:DLY 0');
+    send_scpi(client, 'ACQ:START');
+    pause(0.05);
+end
+
+function set_red_pitaya_output(client, u)
+    if numel(u) > 1
+        u = u(1);
+    end
+    cmd = sprintf('SOUR1:VOLT %0.6f', max(min(u, 1.0), -1.0));
+    send_scpi(client, cmd);
+end
+
+function intensity = read_red_pitaya_adc(client)
+    send_scpi(client, 'ACQ:START');
+    send_scpi(client, 'ACQ:TRIG NOW');
+    pause(0.002);
+    writeline(client, 'ACQ:SOUR1:DATA?');
+    timeout = tic;
+    while client.NumBytesAvailable == 0 && toc(timeout) < 0.5
+        pause(0.001);
+    end
+    available = client.NumBytesAvailable;
+    if available == 0
+        warning('No data available from Red Pitaya ADC.');
+        intensity = NaN;
+        return;
+    end
+    raw = read(client, available, 'char');
+    samples = parse_red_pitaya_vector(char(raw));
+    if isempty(samples)
+        warning('No samples received from Red Pitaya ADC. Returning NaN.');
+        intensity = NaN;
+    else
+        intensity = mean(samples);
+    end
+end
+
+function samples = parse_red_pitaya_vector(raw)
+    tokens = regexp(raw, '{([^}]*)}', 'tokens', 'once');
+    if isempty(tokens)
+        samples = str2double(split(raw, ','));
+    else
+        samples = str2double(split(tokens{1}, ','));
+    end
+    samples = samples(~isnan(samples));
+end
+
+function cleanup_red_pitaya(client)
+    if ~isempty(client) && isvalid(client)
+        try
+            send_scpi(client, 'ACQ:STOP');
+            send_scpi(client, 'OUTPUT1:STATE OFF');
+            clear client;
+        catch
+        end
+    end
+end
+
+function send_scpi(client, cmd)
+    writeline(client, cmd);
+end
+
+function [fig, plots] = create_plots(opts, timeAxis)
+    fig = figure('Name', sprintf('SPGD Control (%s)', opts.Mode), ...
+        'Color', 'w', 'NumberTitle', 'off');
+    t = tiledlayout(fig, 2, 2, 'Padding', 'compact');
+
+    plots.input.ax = nexttile(t, 1);
+    plots.input.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2);
+    xlabel(plots.input.ax, 'Time (s)');
+    ylabel(plots.input.ax, 'Intensity (arb.)');
+    title(plots.input.ax, 'Measured Intensity');
+    grid(plots.input.ax, 'on');
+
+    plots.error.ax = nexttile(t, 2);
+    plots.error.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2, 'Color', [0.85 0.33 0.1]);
+    xlabel(plots.error.ax, 'Time (s)');
+    ylabel(plots.error.ax, 'Error (arb.)');
+    title(plots.error.ax, 'Tracking Error');
+    grid(plots.error.ax, 'on');
+
+    plots.noise.ax = nexttile(t, 3);
+    plots.noise.line = semilogx([1], [nan], 'LineWidth', 1.2, 'Color', [0.47 0.67 0.19]);
+    xlabel(plots.noise.ax, 'Frequency (Hz)');
+    ylabel(plots.noise.ax, 'Noise (dBc/Hz)');
+    title(plots.noise.ax, 'Intensity Noise Spectrum');
+    grid(plots.noise.ax, 'on');
+
+    plots.output.ax = nexttile(t, 4);
+    plots.output.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2, 'Color', [0.13 0.55 0.8]);
+    xlabel(plots.output.ax, 'Time (s)');
+    ylabel(plots.output.ax, 'Control (V)');
+    title(plots.output.ax, 'Actuator Command');
+    grid(plots.output.ax, 'on');
+
+    drawnow;
+end
+
+function update_plots(plots, intensityHistory, errorHistory, controlHistory, timeAxis, opts, k)
+    idx = 1:k;
+    set(plots.input.line, 'XData', timeAxis(idx), 'YData', intensityHistory(idx));
+    set(plots.error.line, 'XData', timeAxis(idx), 'YData', errorHistory(idx));
+    set(plots.output.line, 'XData', timeAxis(idx), 'YData', controlHistory(idx, 1));
+
+    validErrors = errorHistory(idx);
+    validErrors = validErrors(~isnan(validErrors));
+    if numel(validErrors) > 8
+        [pxx, f] = pwelch(validErrors, [], [], [], opts.SampleRate);
+        refPower = max(opts.Target^2, eps);
+        noise = 10 * log10(max(pxx, eps) ./ refPower);
+        set(plots.noise.line, 'XData', f(2:end), 'YData', noise(2:end));
+        plots.noise.ax.XLimMode = 'auto';
+    end
+
+    drawnow limitrate;
+end
+
+function [intensity, state] = simulate_step(state, control, plant, opts)
+    control = control(:);
+    if numel(control) > 1
+        control = control(1);
+    end
+    dt = 1 / opts.SampleRate;
+    a = exp(-dt / plant.TimeConstant);
+    disturbance = plant.DisturbanceAmplitude * sin(2*pi*plant.DisturbanceFrequency*state.t + plant.DisturbancePhase);
+    state.x = a * state.x + (1 - a) * (plant.Gain * control + disturbance);
+    state.t = state.t + dt;
+    noise = plant.NoiseStd * randn();
+    intensity = plant.Offset + state.x + noise;
+end
+
+function plant = local_default_sim_plant()
+    plant.Gain = 0.9;
+    plant.TimeConstant = 2e-3;
+    plant.DisturbanceAmplitude = 0.2;
+    plant.DisturbanceFrequency = 120;
+    plant.DisturbancePhase = 0;
+    plant.NoiseStd = 0.01;
+    plant.Offset = 0.8;
+    plant.InitialState = 0;
+end
+
+function merged = merge_struct(base, override)
+    merged = base;
+    fields = fieldnames(override);
+    for k = 1:numel(fields)
+        merged.(fields{k}) = override.(fields{k});
+    end
+end

--- a/matlab/spgd_control.m
+++ b/matlab/spgd_control.m
@@ -62,8 +62,10 @@ function spgd_control(varargin)
     control = zeros(nActuators, 1);
     referenceControl = control;
     perturb = zeros(nActuators, 1);
+    smoothedGradient = zeros(nActuators, 1);
 
     intensityHistory = zeros(nIter, 1);
+    rawIntensityHistory = zeros(nIter, 1);
     referenceIntensityHistory = zeros(nIter, 1);
     peakIntensityHistory = zeros(nIter, 1);
     efficiencyHistory = zeros(nIter, 1);
@@ -78,9 +80,12 @@ function spgd_control(varargin)
 
     referenceIntensity = -Inf;
     peakIntensity = -Inf;
+    filteredIntensity = NaN;
+    perturbScale = 1;
 
     for k = 1:nIter
-        perturb(:) = opts.Perturbation * (2 * randi([0, 1], nActuators, 1) - 1);
+        currentPerturb = max(opts.MinPerturbationRatio, min(1, perturbScale)) * opts.Perturbation;
+        perturb(:) = currentPerturb * (2 * randi([0, 1], nActuators, 1) - 1);
 
         uPlus = max(min(control + perturb, opts.ControlLimits(2)), opts.ControlLimits(1));
         backend.apply(uPlus);
@@ -116,7 +121,14 @@ function spgd_control(varargin)
         denom(zeroMask) = eps .* sign(perturb(zeroMask) + (perturb(zeroMask) == 0));
         denom(denom == 0) = eps;
         gradient = (yPlus - yMinus) ./ denom;
-        control = control + opts.Gain * gradient;
+        if opts.GradientSmoothFactor <= 0 || k == 1
+            smoothedGradient = gradient;
+        else
+            smoothedGradient = (1 - opts.GradientSmoothFactor) * smoothedGradient + opts.GradientSmoothFactor * gradient;
+        end
+
+        gainScale = max(opts.MinGainRatio, min(1, perturbScale));
+        control = control + (opts.Gain * gainScale) * smoothedGradient;
         control = max(min(control, opts.ControlLimits(2)), opts.ControlLimits(1));
         backend.apply(control);
 
@@ -130,24 +142,29 @@ function spgd_control(varargin)
                 intensity = opts.Target;
             end
         end
-        err = opts.Target - intensity;
+        if ~isfinite(filteredIntensity) || opts.MeasurementSmoothFactor <= 0
+            filteredIntensity = intensity;
+        else
+            filteredIntensity = (1 - opts.MeasurementSmoothFactor) * filteredIntensity + opts.MeasurementSmoothFactor * intensity;
+        end
 
-        peakIntensity = max(peakIntensity, intensity);
+        err = opts.Target - filteredIntensity;
+
+        peakIntensity = max(peakIntensity, filteredIntensity);
 
         if ~isfinite(referenceIntensity)
-            referenceIntensity = intensity;
+            referenceIntensity = filteredIntensity;
             referenceControl = control;
         else
             decayedRef = referenceIntensity * (1 - opts.BestDecayRate);
-            if intensity >= decayedRef
-                referenceIntensity = intensity;
+            referenceIntensity = decayedRef;
+            if filteredIntensity >= referenceIntensity
+                referenceIntensity = filteredIntensity;
                 referenceControl = control;
-            else
-                referenceIntensity = decayedRef;
             end
         end
 
-        efficiency = intensity ./ max(referenceIntensity, eps);
+        efficiency = filteredIntensity ./ max(referenceIntensity, eps);
         if efficiency < opts.EfficiencyThreshold && isfinite(referenceIntensity) && referenceIntensity > 0
             warning(['Efficiency %.3f below %.2f threshold at iteration %d. ', ...
                 'Restoring best-known control.'], efficiency, opts.EfficiencyThreshold, k);
@@ -161,21 +178,25 @@ function spgd_control(varargin)
                     warning('Invalid intensity during restoration attempt %d.', attempt + 1);
                     intensity = referenceIntensity;
                 end
-                peakIntensity = max(peakIntensity, intensity);
+                if ~isfinite(filteredIntensity) || opts.MeasurementSmoothFactor <= 0
+                    filteredIntensity = intensity;
+                else
+                    filteredIntensity = (1 - opts.MeasurementSmoothFactor) * filteredIntensity + opts.MeasurementSmoothFactor * intensity;
+                end
+                peakIntensity = max(peakIntensity, filteredIntensity);
                 if ~isfinite(referenceIntensity)
-                    referenceIntensity = intensity;
+                    referenceIntensity = filteredIntensity;
                     referenceControl = control;
                 else
                     decayedRef = referenceIntensity * (1 - opts.BestDecayRate);
-                    if intensity >= decayedRef
-                        referenceIntensity = intensity;
+                    referenceIntensity = decayedRef;
+                    if filteredIntensity >= referenceIntensity
+                        referenceIntensity = filteredIntensity;
                         referenceControl = control;
-                    else
-                        referenceIntensity = decayedRef;
                     end
                 end
-                efficiency = intensity ./ max(referenceIntensity, eps);
-                err = opts.Target - intensity;
+                efficiency = filteredIntensity ./ max(referenceIntensity, eps);
+                err = opts.Target - filteredIntensity;
                 if efficiency >= opts.EfficiencyThreshold
                     break;
                 end
@@ -184,17 +205,25 @@ function spgd_control(varargin)
             end
         end
 
-        intensityHistory(k) = intensity;
+        rawIntensityHistory(k) = intensity;
+        intensityHistory(k) = filteredIntensity;
         referenceIntensityHistory(k) = referenceIntensity;
         peakIntensityHistory(k) = peakIntensity;
         efficiencyHistory(k) = efficiency;
         errorHistory(k) = err;
         controlHistory(k, :) = control;
 
+        if isfinite(referenceIntensity) && referenceIntensity > 0
+            drop = max(0, efficiency - opts.EfficiencyThreshold) / max(1 - opts.EfficiencyThreshold, eps);
+            perturbScale = max(opts.MinPerturbationRatio, min(1, 1 - drop));
+        else
+            perturbScale = 1;
+        end
+
         if mod(k, opts.PlotUpdateInterval) == 0 || k == nIter
-            update_plots(plots, intensityHistory, referenceIntensityHistory, ...
-                peakIntensityHistory, efficiencyHistory, errorHistory, controlHistory, ...
-                timeAxis, opts, k);
+            update_plots(plots, intensityHistory, rawIntensityHistory, ...
+                referenceIntensityHistory, peakIntensityHistory, efficiencyHistory, ...
+                errorHistory, controlHistory, timeAxis, opts, k);
         end
 
         if ~isvalid(fig)
@@ -206,10 +235,10 @@ function spgd_control(varargin)
     backend.apply(control); % ensure actuator is left at last value
     drawnow;
 
-    fprintf(['\nSPGD completed %d iterations in %s mode. Final intensity %.4f, ' ...
-        'reference %.4f, peak %.4f (efficiency %.3f), error %.4f.\n'], ...
-        k, opts.Mode, intensityHistory(k), referenceIntensity, peakIntensity, ...
-        efficiencyHistory(k), errorHistory(k));
+    fprintf(['\nSPGD completed %d iterations in %s mode. Final intensity %.4f ' ...
+        '(raw %.4f), reference %.4f, peak %.4f (efficiency %.3f), error %.4f.\n'], ...
+        k, opts.Mode, intensityHistory(k), rawIntensityHistory(k), referenceIntensity, ...
+        peakIntensity, efficiencyHistory(k), errorHistory(k));
 end
 
 function opts = parse_inputs(varargin)
@@ -233,6 +262,10 @@ function opts = parse_inputs(varargin)
     addParameter(p, 'BestDecayRate', 1e-3, @(x) validateattributes(x, {'numeric'}, {'scalar', '>=', 0, '<', 1}));
     addParameter(p, 'RestoreMaxAttempts', 5, @(x) validateattributes(x, {'numeric'}, {'scalar', 'integer', '>=', 1}));
     addParameter(p, 'ControlLimits', [-1, 1], @(x) validateattributes(x, {'numeric'}, {'vector', 'numel', 2, 'increasing'}));
+    addParameter(p, 'MeasurementSmoothFactor', 0.3, @(x) validateattributes(x, {'numeric'}, {'scalar', '>=', 0, '<=', 1}));
+    addParameter(p, 'GradientSmoothFactor', 0.2, @(x) validateattributes(x, {'numeric'}, {'scalar', '>=', 0, '<=', 1}));
+    addParameter(p, 'MinPerturbationRatio', 0.1, @(x) validateattributes(x, {'numeric'}, {'scalar', '>', 0, '<=', 1}));
+    addParameter(p, 'MinGainRatio', 0.1, @(x) validateattributes(x, {'numeric'}, {'scalar', '>', 0, '<=', 1}));
     parse(p, varargin{:});
 
     opts = p.Results;
@@ -379,16 +412,17 @@ function [fig, plots] = create_plots(opts, timeAxis)
     t = tiledlayout(fig, 2, 2, 'Padding', 'compact');
 
     plots.input.ax = nexttile(t, 1);
-    plots.input.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2);
     hold(plots.input.ax, 'on');
+    plots.input.rawLine = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 0.8, 'Color', [0.75 0.75 0.75]);
+    plots.input.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2, 'Color', [0.0 0.45 0.74]);
     plots.input.referenceLine = plot(timeAxis, nan(size(timeAxis)), '--', 'LineWidth', 1.1, 'Color', [0.49 0.18 0.56]);
     plots.input.peakLine = plot(timeAxis, nan(size(timeAxis)), ':', 'LineWidth', 1, 'Color', [0.3 0.3 0.3]);
     hold(plots.input.ax, 'off');
     xlabel(plots.input.ax, 'Time (s)');
     ylabel(plots.input.ax, 'Intensity (arb.)');
-    title(plots.input.ax, 'Measured Intensity');
+    title(plots.input.ax, 'Measured Intensity (filtered vs. raw)');
     grid(plots.input.ax, 'on');
-    lgd = legend(plots.input.ax, {'Intensity', 'Reference (>=95%)', 'Peak'}, 'Location', 'best');
+    lgd = legend(plots.input.ax, {'Filtered', 'Raw', 'Reference (>=95%)', 'Peak'}, 'Location', 'best');
     set(lgd, 'AutoUpdate', 'off');
 
     plots.error.ax = nexttile(t, 2);
@@ -422,10 +456,11 @@ function [fig, plots] = create_plots(opts, timeAxis)
     drawnow;
 end
 
-function update_plots(plots, intensityHistory, referenceIntensityHistory, peakIntensityHistory, ...
-    efficiencyHistory, errorHistory, controlHistory, timeAxis, opts, k)
+function update_plots(plots, intensityHistory, rawIntensityHistory, referenceIntensityHistory, ...
+    peakIntensityHistory, efficiencyHistory, errorHistory, controlHistory, timeAxis, opts, k)
     idx = 1:k;
     set(plots.input.line, 'XData', timeAxis(idx), 'YData', intensityHistory(idx));
+    set(plots.input.rawLine, 'XData', timeAxis(idx), 'YData', rawIntensityHistory(idx));
     set(plots.input.referenceLine, 'XData', timeAxis(idx), 'YData', referenceIntensityHistory(idx));
     set(plots.input.peakLine, 'XData', timeAxis(idx), 'YData', peakIntensityHistory(idx));
     set(plots.error.line, 'XData', timeAxis(idx), 'YData', errorHistory(idx));

--- a/matlab/spgd_control.m
+++ b/matlab/spgd_control.m
@@ -60,9 +60,13 @@ function spgd_control(varargin)
     nIter = opts.Iterations;
     nActuators = opts.NumActuators;
     control = zeros(nActuators, 1);
+    referenceControl = control;
     perturb = zeros(nActuators, 1);
 
     intensityHistory = zeros(nIter, 1);
+    referenceIntensityHistory = zeros(nIter, 1);
+    peakIntensityHistory = zeros(nIter, 1);
+    efficiencyHistory = zeros(nIter, 1);
     errorHistory = zeros(nIter, 1);
     controlHistory = zeros(nIter, nActuators);
     timeAxis = (0:nIter-1).' ./ opts.SampleRate;
@@ -72,14 +76,19 @@ function spgd_control(varargin)
     backend.apply(control);
     pause(0.05); % allow the output to settle
 
+    referenceIntensity = -Inf;
+    peakIntensity = -Inf;
+
     for k = 1:nIter
         perturb(:) = opts.Perturbation * (2 * randi([0, 1], nActuators, 1) - 1);
 
-        backend.apply(control + perturb);
+        uPlus = max(min(control + perturb, opts.ControlLimits(2)), opts.ControlLimits(1));
+        backend.apply(uPlus);
         pause(opts.SampleHoldTime);
         yPlus = backend.measure();
 
-        backend.apply(control - perturb);
+        uMinus = max(min(control - perturb, opts.ControlLimits(2)), opts.ControlLimits(1));
+        backend.apply(uMinus);
         pause(opts.SampleHoldTime);
         yMinus = backend.measure();
 
@@ -89,19 +98,26 @@ function spgd_control(varargin)
             if k > 1
                 intensityHistory(k) = intensityHistory(k-1);
                 errorHistory(k) = errorHistory(k-1);
+                referenceIntensityHistory(k) = referenceIntensityHistory(k-1);
+                peakIntensityHistory(k) = peakIntensityHistory(k-1);
+                efficiencyHistory(k) = efficiencyHistory(k-1);
             else
                 intensityHistory(k) = NaN;
                 errorHistory(k) = NaN;
+                referenceIntensityHistory(k) = NaN;
+                peakIntensityHistory(k) = NaN;
+                efficiencyHistory(k) = NaN;
             end
             continue;
         end
 
-        denom = 2 * perturb;
+        denom = uPlus - uMinus;
         zeroMask = abs(denom) < eps;
         denom(zeroMask) = eps .* sign(perturb(zeroMask) + (perturb(zeroMask) == 0));
         denom(denom == 0) = eps;
         gradient = (yPlus - yMinus) ./ denom;
         control = control + opts.Gain * gradient;
+        control = max(min(control, opts.ControlLimits(2)), opts.ControlLimits(1));
         backend.apply(control);
 
         pause(opts.SampleHoldTime);
@@ -116,12 +132,68 @@ function spgd_control(varargin)
         end
         err = opts.Target - intensity;
 
+        peakIntensity = max(peakIntensity, intensity);
+
+        if ~isfinite(referenceIntensity)
+            referenceIntensity = intensity;
+            referenceControl = control;
+        else
+            decayedRef = referenceIntensity * (1 - opts.BestDecayRate);
+            if intensity >= decayedRef
+                referenceIntensity = intensity;
+                referenceControl = control;
+            else
+                referenceIntensity = decayedRef;
+            end
+        end
+
+        efficiency = intensity ./ max(referenceIntensity, eps);
+        if efficiency < opts.EfficiencyThreshold && isfinite(referenceIntensity) && referenceIntensity > 0
+            warning(['Efficiency %.3f below %.2f threshold at iteration %d. ', ...
+                'Restoring best-known control.'], efficiency, opts.EfficiencyThreshold, k);
+            control = referenceControl;
+            backend.apply(control);
+            pause(opts.SampleHoldTime);
+            attempt = 0;
+            while attempt < opts.RestoreMaxAttempts
+                intensity = backend.measure();
+                if ~isfinite(intensity)
+                    warning('Invalid intensity during restoration attempt %d.', attempt + 1);
+                    intensity = referenceIntensity;
+                end
+                peakIntensity = max(peakIntensity, intensity);
+                if ~isfinite(referenceIntensity)
+                    referenceIntensity = intensity;
+                    referenceControl = control;
+                else
+                    decayedRef = referenceIntensity * (1 - opts.BestDecayRate);
+                    if intensity >= decayedRef
+                        referenceIntensity = intensity;
+                        referenceControl = control;
+                    else
+                        referenceIntensity = decayedRef;
+                    end
+                end
+                efficiency = intensity ./ max(referenceIntensity, eps);
+                err = opts.Target - intensity;
+                if efficiency >= opts.EfficiencyThreshold
+                    break;
+                end
+                attempt = attempt + 1;
+                pause(opts.SampleHoldTime);
+            end
+        end
+
         intensityHistory(k) = intensity;
+        referenceIntensityHistory(k) = referenceIntensity;
+        peakIntensityHistory(k) = peakIntensity;
+        efficiencyHistory(k) = efficiency;
         errorHistory(k) = err;
         controlHistory(k, :) = control;
 
         if mod(k, opts.PlotUpdateInterval) == 0 || k == nIter
-            update_plots(plots, intensityHistory, errorHistory, controlHistory, ...
+            update_plots(plots, intensityHistory, referenceIntensityHistory, ...
+                peakIntensityHistory, efficiencyHistory, errorHistory, controlHistory, ...
                 timeAxis, opts, k);
         end
 
@@ -134,8 +206,10 @@ function spgd_control(varargin)
     backend.apply(control); % ensure actuator is left at last value
     drawnow;
 
-    fprintf('\nSPGD completed %d iterations in %s mode. Final intensity %.4f, error %.4f.\n', ...
-        k, opts.Mode, intensityHistory(k), errorHistory(k));
+    fprintf(['\nSPGD completed %d iterations in %s mode. Final intensity %.4f, ' ...
+        'reference %.4f, peak %.4f (efficiency %.3f), error %.4f.\n'], ...
+        k, opts.Mode, intensityHistory(k), referenceIntensity, peakIntensity, ...
+        efficiencyHistory(k), errorHistory(k));
 end
 
 function opts = parse_inputs(varargin)
@@ -155,11 +229,16 @@ function opts = parse_inputs(varargin)
     addParameter(p, 'Seed', 1, @(x) validateattributes(x, {'numeric'}, {'scalar', 'real'}));
     addParameter(p, 'SimulationPlant', struct(), @(x) isstruct(x));
     addParameter(p, 'SampleHoldTime', 1e-3, @(x) validateattributes(x, {'numeric'}, {'scalar', 'nonnegative'}));
+    addParameter(p, 'EfficiencyThreshold', 0.95, @(x) validateattributes(x, {'numeric'}, {'scalar', '>', 0, '<=', 1}));
+    addParameter(p, 'BestDecayRate', 1e-3, @(x) validateattributes(x, {'numeric'}, {'scalar', '>=', 0, '<', 1}));
+    addParameter(p, 'RestoreMaxAttempts', 5, @(x) validateattributes(x, {'numeric'}, {'scalar', 'integer', '>=', 1}));
+    addParameter(p, 'ControlLimits', [-1, 1], @(x) validateattributes(x, {'numeric'}, {'vector', 'numel', 2, 'increasing'}));
     parse(p, varargin{:});
 
     opts = p.Results;
     opts.Mode = lower(string(opts.Mode));
     opts.RedPitayaHost = char(opts.RedPitayaHost);
+    opts.ControlLimits = sort(opts.ControlLimits(:).');
 
     if opts.NumActuators ~= 1
         warning(['The provided SPGD implementation drives a single actuator. ', ...
@@ -199,7 +278,13 @@ function backend = create_simulation_backend(opts)
     end
 
     function intensity = measure_sim()
-        [intensity, state] = simulate_step(state, backendState.control, plant, opts);
+        nHold = max(1, round(opts.SampleHoldTime * opts.SampleRate));
+        acc = 0;
+        for ii = 1:nHold
+            [sample, state] = simulate_step(state, backendState.control, plant, opts);
+            acc = acc + sample;
+        end
+        intensity = acc / nHold;
     end
 end
 
@@ -295,10 +380,16 @@ function [fig, plots] = create_plots(opts, timeAxis)
 
     plots.input.ax = nexttile(t, 1);
     plots.input.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2);
+    hold(plots.input.ax, 'on');
+    plots.input.referenceLine = plot(timeAxis, nan(size(timeAxis)), '--', 'LineWidth', 1.1, 'Color', [0.49 0.18 0.56]);
+    plots.input.peakLine = plot(timeAxis, nan(size(timeAxis)), ':', 'LineWidth', 1, 'Color', [0.3 0.3 0.3]);
+    hold(plots.input.ax, 'off');
     xlabel(plots.input.ax, 'Time (s)');
     ylabel(plots.input.ax, 'Intensity (arb.)');
     title(plots.input.ax, 'Measured Intensity');
     grid(plots.input.ax, 'on');
+    lgd = legend(plots.input.ax, {'Intensity', 'Reference (>=95%)', 'Peak'}, 'Location', 'best');
+    set(lgd, 'AutoUpdate', 'off');
 
     plots.error.ax = nexttile(t, 2);
     plots.error.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2, 'Color', [0.85 0.33 0.1]);
@@ -315,19 +406,33 @@ function [fig, plots] = create_plots(opts, timeAxis)
     grid(plots.noise.ax, 'on');
 
     plots.output.ax = nexttile(t, 4);
+    yyaxis(plots.output.ax, 'left');
+    plots.efficiency.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2, 'Color', [0.0 0.45 0.74]);
+    ylabel(plots.output.ax, 'Efficiency');
+    ylim(plots.output.ax, [0 1.05]);
+
+    yyaxis(plots.output.ax, 'right');
     plots.output.line = plot(timeAxis, nan(size(timeAxis)), 'LineWidth', 1.2, 'Color', [0.13 0.55 0.8]);
-    xlabel(plots.output.ax, 'Time (s)');
     ylabel(plots.output.ax, 'Control (V)');
-    title(plots.output.ax, 'Actuator Command');
+
+    xlabel(plots.output.ax, 'Time (s)');
+    title(plots.output.ax, sprintf('Efficiency & Control (threshold %.2f)', opts.EfficiencyThreshold));
     grid(plots.output.ax, 'on');
 
     drawnow;
 end
 
-function update_plots(plots, intensityHistory, errorHistory, controlHistory, timeAxis, opts, k)
+function update_plots(plots, intensityHistory, referenceIntensityHistory, peakIntensityHistory, ...
+    efficiencyHistory, errorHistory, controlHistory, timeAxis, opts, k)
     idx = 1:k;
     set(plots.input.line, 'XData', timeAxis(idx), 'YData', intensityHistory(idx));
+    set(plots.input.referenceLine, 'XData', timeAxis(idx), 'YData', referenceIntensityHistory(idx));
+    set(plots.input.peakLine, 'XData', timeAxis(idx), 'YData', peakIntensityHistory(idx));
     set(plots.error.line, 'XData', timeAxis(idx), 'YData', errorHistory(idx));
+    yyaxis(plots.output.ax, 'left');
+    set(plots.efficiency.line, 'XData', timeAxis(idx), 'YData', efficiencyHistory(idx));
+    ylim(plots.output.ax, [0, max(1.05, max(efficiencyHistory(idx))*1.05)]);
+    yyaxis(plots.output.ax, 'right');
     set(plots.output.line, 'XData', timeAxis(idx), 'YData', controlHistory(idx, 1));
 
     validErrors = errorHistory(idx);


### PR DESCRIPTION
## Summary
- add a MATLAB `spgd_control` utility that can run either in simulation or against a Red Pitaya via SCPI while plotting intensity, error, PSD and actuator output in real time
- include helper routines for configuring the Red Pitaya connection and parsing ADC responses, plus a simulation plant that can be customised
- document usage, tuning parameters and hardware notes in `matlab/README.md`

## Testing
- not run (manual testing recommended)


------
https://chatgpt.com/codex/tasks/task_e_68e7849f0e788324840dbe1d424a6d4c