### PR TITLE
Improve Yb401 NALM simulation with lock detection and scans

### DIFF
--- a/IP_CQEM_FD.m
+++ b/IP_CQEM_FD.m
@@ -1,0 +1,88 @@
+function [u1,nf,Plotdata] = IP_CQEM_FD(u0,dt,dz,mod,fo,tol,dplot,quiet)
+%IP_CQEM_FD Interaction-picture CQEM solver for the GNLSE.
+
+    nt = length(u0);
+    w = fftshift(2*pi*(-nt/2:nt/2-1)/(dt*nt));
+    t_vec = (-nt/2:1:nt/2-1)*dt;
+    [hrw,fr] = Raman_response_w(t_vec,mod);
+
+    ufft = fft(u0);
+    propagedlength = 0;
+    u1 = u0;
+    nf = 1;
+
+    if isfield(mod,'gssdB')
+        gain_w = filter_lorentz_tf(u1,mod.fbw,mod.fc,fo,1/dt/nt);
+        alpha_0 = mod.alpha;
+    end
+
+    if dplot == 1
+        z_all = [];
+        ufft_z = [];
+        u_z = [];
+    end
+
+    if ~quiet
+        fprintf(1,'\nSegment length %.1f cm ...', mod.L*1e2);
+    end
+
+    while propagedlength < mod.L
+        if (dz + propagedlength) > mod.L
+            dz = mod.L - propagedlength;
+        end
+
+        if isfield(mod,'gssdB')
+            Pin0 = sum(u1.*conj(u1))/nt;
+            gain = gain_saturated2(Pin0,mod.gssdB,mod.PsatdBm).*gain_w;
+            mod.alpha = alpha_0 - gain;
+        end
+
+        LOP = Linearoperator_w(mod.alpha,mod.betaw,w);
+        PhotonN = sum((abs(ufft).^2)./(w + 2*pi*fo));
+        PhotonN_z = sum(exp(-dz*fftshift(mod.alpha)).*(abs(ufft).^2)./(w + 2*pi*fo));
+
+        halfstep = exp(LOP*dz/2);
+        uip = halfstep.*ufft;
+        k1 = halfstep*dz.*NonLinearoperator_w(u1,mod.gamma,w,fo,fr,hrw,dt,mod);
+
+        uhalf2 = ifft(uip + k1/2);
+        k2 = dz*NonLinearoperator_w(uhalf2,mod.gamma,w,fo,fr,hrw,dt,mod);
+
+        uhalf3 = ifft(uip + k2/2);
+        k3 = dz*NonLinearoperator_w(uhalf3,mod.gamma,w,fo,fr,hrw,dt,mod);
+
+        uhalf4 = ifft(halfstep.*(uip + k3));
+        k4 = dz*NonLinearoperator_w(uhalf4,mod.gamma,w,fo,fr,hrw,dt,mod);
+
+        uaux = halfstep.*(uip + k1/6 + k2/3 + k3/3) + k4/6;
+        propagedlength = propagedlength + dz;
+
+        error = abs(sum((abs(uaux).^2)./(w+2*pi*fo))-PhotonN_z)/PhotonN_z;
+        if error > 2*tol
+            propagedlength = propagedlength - dz;
+            dz = dz/2;
+        else
+            ufft = uaux;
+            u1 = ifft(ufft);
+            if error > tol
+                dz = dz/(2^0.2);
+            elseif error < 0.5*tol
+                dz = dz*(2^0.2);
+            end
+            if dplot == 1
+                z_all = [z_all; propagedlength]; %#ok<AGROW>
+                ufft_z = [ufft_z; abs(fftshift(ufft))]; %#ok<AGROW>
+                u_z = [u_z; u1]; %#ok<AGROW>
+            end
+        end
+        nf = nf + 16;
+    end
+
+    if dplot == 1
+        Plotdata.z = z_all;
+        Plotdata.ufft = ufft_z;
+        Plotdata.u = abs(u_z);
+    else
+        Plotdata = struct('z',[],'ufft',[],'u',[]);
+    end
+end

--- a/Linearoperator_w.m
+++ b/Linearoperator_w.m
@@ -1,0 +1,13 @@
+function LOP = Linearoperator_w(alpha,betaw,w)
+%LINEAROPERATOR_W Construct the linear operator in the frequency domain.
+
+    LOP = -fftshift(alpha/2);
+    if length(betaw) == length(w)
+        LOP = LOP - 1i*betaw;
+        LOP = fftshift(LOP);
+    else
+        for ii = 0:length(betaw)-1
+            LOP = LOP - 1i*betaw(ii+1)*(w).^ii/factorial(ii);
+        end
+    end
+end

--- a/NonLinearoperator_w.m
+++ b/NonLinearoperator_w.m
@@ -1,0 +1,11 @@
+function NLOP = NonLinearoperator_w(u_t,gamma,w,fo,fr,hrw,dt,mod)
+%NONLINEAROPERATOR_W Frequency-domain nonlinear operator of the GNLSE.
+
+    if ~isfield(mod,'ssp') || mod.ssp == 1
+        NLOP = -1i*gamma*(1 + w/(2*pi*fo)).*fft(((1-fr)*u_t.*abs(u_t).^2) ...
+            + fr*dt*u_t.*ifft(hrw.*fft(abs(u_t).^2)));
+    else
+        NLOP = -1i*gamma*fft(((1-fr)*u_t.*abs(u_t).^2) ...
+            + fr*dt*u_t.*ifft(hrw.*fft(abs(u_t).^2)));
+    end
+end

--- a/Raman_response_w.m
+++ b/Raman_response_w.m
@@ -1,0 +1,22 @@
+function [hrw,fr] = Raman_response_w(t,mod)
+%RAMAN_RESPONSE_W Raman response in the frequency domain.
+
+    if isfield(mod,'raman') && mod.raman == 0
+        hrw = 0;
+        fr = 0;
+    else
+        t1 = 12.2e-3;
+        t2 = 32e-3;
+        tb = 96e-3;
+        fc = 0.04;
+        fb = 0.21;
+        fa = 1 - fc - fb;
+        fr = 0.245;
+
+        tres = t - t(1);
+        ha = ((t1^2+t2^2)/(t1*t2^2)).*exp(-tres/t2).*sin(tres/t1);
+        hb = ((2*tb - tres)./tb^2).*exp(-tres/tb);
+        hr = (fa + fc)*ha + fb*hb;
+        hrw = fft(hr);
+    end
+end

--- a/apply_cfbg.m
+++ b/apply_cfbg.m
@@ -1,0 +1,58 @@
+function [u_out, Plotdata] = apply_cfbg(u_in, cfbg, fo, df, c)
+%APPLY_CFBG   Apply a Gaussian-profiled chirped fibre Bragg grating
+%   [u_out, Plotdata] = APPLY_CFBG(u_in, cfbg, fo, df, c) multiplies the
+%   field u_in by the complex transfer function of a CFBG described by
+%   the parameter struct cfbg.  The grating provides a Gaussian spectral
+%   reflectivity with peak power reflectivity cfbg.reflectivity and adds a
+%   quadratic spectral phase term determined by the specified dispersion
+%   coefficient (group-delay slope in ps/nm).
+%
+%   The cfbg structure must provide:
+%       lambda_c    - central wavelength (nm)
+%       bandwidth   - FWHM bandwidth (nm)
+%       reflectivity- peak power reflectivity (0..1)
+%       dispersion  - group delay slope (ps/nm)
+%       fc          - central frequency (THz)
+%       beta2       - second-order phase coefficient (ps^2)
+%
+%   Plotdata holds replicated spectra/time traces so the caller can append
+%   them to the master Plotdata diagnostics matrix (mimicking other fibre
+%   sections in the code base).
+%
+%   The implementation assumes the signal is defined around fo (THz) with
+%   a sampling step df (THz) and that the speed of light is provided in
+%   nm/ps via c.
+
+Ui = fft(u_in);
+N = numel(Ui);
+
+% Frequency grid around the carrier
+freq = (-(N/2)*df:df:(N/2-1)*df) + fo;          % THz
+freq(abs(freq) < eps) = eps;                    % avoid division by zero
+omega = 2*pi*freq;                               % rad/ps
+omega0 = 2*pi*cfbg.fc;                           % rad/ps
+lambda = c./freq;                                % nm
+
+% Gaussian reflectivity profile
+sigma = cfbg.bandwidth / (2*sqrt(2*log(2)));      % nm
+amp = sqrt(cfbg.reflectivity) * ...
+    exp(-0.5 * ((lambda - cfbg.lambda_c) ./ sigma).^2);
+
+% Quadratic spectral phase from the dispersion coefficient
+phase = 0.5 * cfbg.beta2 * (omega - omega0).^2;   % rad
+
+transfer = amp .* exp(1i * phase);
+
+% Apply transfer function (spectrum handled in centred form)
+Ui_shift = fftshift(Ui);
+Uo_shift = Ui_shift .* transfer;
+Uo = ifftshift(Uo_shift);
+
+u_out = ifft(Uo);
+
+% Diagnostics for downstream plots
+Plotdata.ufft = repmat(abs(fftshift(fft(u_out))), 20, 1);
+Plotdata.u = repmat(u_out, 20, 1);
+Plotdata.transfer = transfer;
+
+end

--- a/compute_locking_metrics.m
+++ b/compute_locking_metrics.m
@@ -1,0 +1,34 @@
+function metrics = compute_locking_metrics(u_field, dt, f, fo, c)
+%COMPUTE_LOCKING_METRICS  Derive pulse metrics for lock-state detection.
+%   metrics = COMPUTE_LOCKING_METRICS(u_field, dt, f, fo, c) calculates
+%   energy, peak power, temporal FWHM, spectral FWHM (nm) and RMS frequency
+%   shift for the complex field u_field sampled at dt (ps).  The frequency
+%   vector f (THz) is centred around zero, fo is the carrier frequency (THz)
+%   and c is the speed of light in nm/ps.
+
+intensity = abs(u_field).^2;
+metrics.energy_pJ = dt * sum(intensity);          % pulse energy (pJ)
+metrics.peak_power_W = max(intensity);            % peak power (W)
+
+% Temporal FWHM in ps
+[width_samples, ~, ~] = fwhm(intensity);
+metrics.fwhm_time_ps = width_samples * dt;
+
+% Chirp estimate using instantaneous frequency deviation
+phase = unwrap(angle(u_field));
+if numel(phase) > 1
+    inst_freq = -diff(phase) / (2*pi*dt);          % THz
+    metrics.chirp_rms_THz = rms(inst_freq);
+else
+    metrics.chirp_rms_THz = 0;
+end
+
+% Spectral FWHM using wavelength axis
+spec = fftshift(abs(fft(u_field)).^2);
+spec = spec / (max(spec) + eps);
+lambda_axis = c ./ (f + fo);
+metrics.spectral_width_nm = measure_spectral_width(lambda_axis, spec);
+metrics.lambda_axis = lambda_axis;                % retain for inspection
+metrics.spectrum = spec;
+
+end

--- a/coupler.m
+++ b/coupler.m
@@ -1,0 +1,10 @@
+function [u1o,u2o] = coupler(u1i,u2i,rho)
+%COUPLER Fibre coupler matrix for complex field envelopes.
+%   [U1O,U2O] = COUPLER(U1I,U2I,RHO) mixes the input fields U1I and U2I
+%   according to the power splitting ratio RHO (0..1) using the standard
+%   unitary 2x2 coupler matrix.
+
+    rho = max(0,min(1,rho));
+    u1o = sqrt(rho)*u1i + 1i*sqrt(1-rho)*u2i;
+    u2o = 1i*sqrt(1-rho)*u1i + sqrt(rho)*u2i;
+end

--- a/default_yb401_params.m
+++ b/default_yb401_params.m
@@ -1,0 +1,72 @@
+function params = default_yb401_params()
+%DEFAULT_YB401_PARAMS  Return baseline parameters for the Yb401-PM NALM
+%   params = DEFAULT_YB401_PARAMS() builds a struct describing the cavity,
+%   gain media, CFBG, and numerical grid used by the Yb401-PM based NALM
+%   mode-locking simulations.  The values are derived from typical fibre and
+%   component data sheets and tuned to favour broad-band pulses near 1030 nm.
+%
+%   The returned struct contains:
+%       params.constants   - numerical constants (speed of light)
+%       params.pulse       - input pulse specification
+%       params.fibre       - base fibre properties
+%       params.sections    - lengths and gains of cavity sections
+%       params.cfbg        - chirped fibre Bragg grating parameters
+%       params.couplers    - NALM and output coupler ratios
+%       params.grid        - temporal/frequency grid configuration
+%
+%   These defaults can be modified prior to invoking RUN_YB401_NALM.
+
+params.constants.c = 299792.458;            % speed of light (nm/ps)
+
+% Input pulse slightly above the fundamental soliton order with a few-ps
+% duration to ease self-starting while allowing significant spectral
+% broadening once gain builds up.
+params.pulse.N2 = 1.35^2;                   % soliton order squared
+params.pulse.tfwhm = 3.5;                   % FWHM (ps)
+params.pulse.lambda = 1030;                 % central wavelength (nm)
+params.pulse.noise_level = 5e-3;            % relative Gaussian noise
+params.pulse.random_seed = 0;               % deterministic seed for repeatability
+
+% Yb401-PM fibre properties (effective area from 6 um MFD, D ~= 20 ps/nm/km)
+params.fibre.Aeff = 28.3;                   % effective mode area (um^2)
+params.fibre.n2 = 26;                       % Kerr coefficient (10^-16 cm^2/W)
+params.fibre.alpha_dB_per_m = 0.25;         % loss coefficient (dB/m)
+params.fibre.beta2 = -11.26;                % ps^2/km (converted from D)
+params.fibre.beta3 = 0.1;                   % ps^3/km
+params.fibre.include_raman = false;
+params.fibre.include_ssp = false;
+
+% Section lengths (km) roughly matching a compact laboratory cavity.  These
+% can be altered freely by callers or the parameter scan utility.
+sections.smf_link = 0.0005;                 % fibre before main gain (0.5 m)
+sections.amf_main = struct('L', 0.0006, ... % main gain fibre (0.6 m)
+                           'gssdB', 38, ...% small-signal gain (dB)
+                           'PsatdBm', 33, ...
+                           'bandwidth_nm', 8);
+sections.smf_output = 0.0006;               % fibre between gain and NALM (0.6 m)
+sections.smf_pre = 0.0006;                  % first NALM passive arm segment (0.6 m)
+sections.amf_nalm = struct('L', 0.0004, ... % NALM gain fibre (0.4 m)
+                           'gssdB', 27, ...
+                           'PsatdBm', 32, ...
+                           'bandwidth_nm', 6);
+sections.smf_post = 0.0007;                 % second NALM passive arm segment (0.7 m)
+sections.smf_linear = 0.0004;               % fibre to output branch (0.4 m)
+params.sections = sections;
+
+% Chirped fibre Bragg grating (linear arm reflector)
+params.cfbg.lambda_c = params.pulse.lambda;
+params.cfbg.bandwidth = 20;                 % nm
+params.cfbg.reflectivity = 0.20;            % peak power reflectivity
+params.cfbg.dispersion = 0.1;               % ps/nm group delay slope
+
+% Coupler ratios
+params.couplers.rho = 0.45;                 % NALM 45/55 coupler
+params.couplers.rho_out = 0.25;             % output coupler
+
+% Numerical grid
+params.grid.nt = 2^12;                      % number of temporal samples
+params.grid.time_window = 40;               % total time window (ps)
+params.grid.dz = 5e-6;                      % initial step size (km)
+params.grid.tol = 1e-4;                     % adaptive tolerance
+
+end

--- a/filter_gauss.m
+++ b/filter_gauss.m
@@ -1,0 +1,11 @@
+function uo = filter_gauss(ui,f3dB,fc,n,fo,df)
+%FILTER_GAUSS Apply an N-th order Gaussian spectral filter to a field.
+%   UO = FILTER_GAUSS(UI,F3DB,FC,N,FO,DF) filters the field UI using a
+%   Gaussian transfer function with 3 dB bandwidth F3DB centred at FC.
+
+    Ui = fft(ui);
+    N = size(Ui,2);
+    f = fftshift((-(N/2)*df:df:(N/2-1)*df) + fo);
+    Tf = exp(-log(sqrt(2))*(2/f3dB*(f-fc)).^(2*n));
+    uo = ifft(Ui.*Tf);
+end

--- a/filter_lorentz_tf.m
+++ b/filter_lorentz_tf.m
@@ -1,0 +1,10 @@
+function tf = filter_lorentz_tf(ui,fbw,fc,fo,df)
+%FILTER_LORENTZ_TF Return the normalised Lorentzian gain transfer function.
+%   TF = FILTER_LORENTZ_TF(UI,FBW,FC,FO,DF) computes the Lorentzian spectral
+%   profile centred at FC with full-width FBW for an input field UI.
+
+    N = size(ui,2);
+    f = (-(N/2)*df:df:(N/2-1)*df) + fo;
+    tf = (fbw)/2/pi./((f-fc).^2+(fbw/2)^2);
+    tf = tf/max(tf(:));
+end

--- a/fwhm.m
+++ b/fwhm.m
@@ -1,0 +1,13 @@
+function [width,I_l,I_r] = fwhm(x)
+%FWHM Compute the discrete full width at half maximum of vector X.
+
+    [peak, ind_peak] = max(x);
+    half_peak = peak/2;
+    x_l = x(1:ind_peak);
+    x_r = x(ind_peak:end);
+    I_l_rel = find(fliplr(x_l) <= half_peak, 1, 'first');
+    I_r_rel = find(x_r <= half_peak, 1, 'first');
+    width = I_l_rel + I_r_rel;
+    I_l = ind_peak - I_l_rel;
+    I_r = ind_peak + I_r_rel - 1;
+end

--- a/gain_saturated2.m
+++ b/gain_saturated2.m
@@ -1,0 +1,7 @@
+function gain = gain_saturated2(Pin,gssdB,PsatdBm)
+%GAIN_SATURATED2 Calculate the saturated gain coefficient of the amplifier.
+
+    gss = 10^(gssdB/10);
+    Psat = 10^((PsatdBm-30)/10);
+    gain = gss/(1+Pin/Psat);
+end

--- a/measure_spectral_width.m
+++ b/measure_spectral_width.m
@@ -1,0 +1,43 @@
+function width_nm = measure_spectral_width(lambda_axis, spectrum)
+%MEASURE_SPECTRAL_WIDTH  Estimate the FWHM bandwidth in nanometres.
+%   width_nm = MEASURE_SPECTRAL_WIDTH(lambda_axis, spectrum) normalises the
+%   spectral power array "spectrum" to its maximum and measures the full
+%   width at half maximum along the wavelength vector lambda_axis.  The
+%   function assumes lambda_axis is monotonically increasing or decreasing.
+%
+%   If multiple peaks exist, the outermost half-maximum crossings are used.
+%   When the spectrum never crosses the half-maximum level the returned
+%   bandwidth is zero.
+
+if isempty(lambda_axis) || isempty(spectrum)
+    width_nm = 0;
+    return;
+end
+
+% Ensure column vectors and sort by wavelength to guarantee monotonicity.
+lambda_axis = lambda_axis(:);
+spectrum = spectrum(:);
+[lambda_sorted, idx] = sort(lambda_axis, 'ascend');
+spectrum_sorted = spectrum(idx);
+
+if max(spectrum_sorted) <= 0
+    width_nm = 0;
+    return;
+end
+
+spec_norm = spectrum_sorted ./ max(spectrum_sorted);
+half_level = 0.5;
+above_half = spec_norm >= half_level;
+
+if ~any(above_half)
+    width_nm = 0;
+    return;
+end
+
+first_idx = find(above_half, 1, 'first');
+last_idx = find(above_half, 1, 'last');
+
+width_nm = lambda_sorted(last_idx) - lambda_sorted(first_idx);
+width_nm = abs(width_nm);
+
+end

--- a/run_yb401_nalm.m
+++ b/run_yb401_nalm.m
@@ -1,0 +1,376 @@
+function [result, Plotdata] = run_yb401_nalm(params, options)
+%RUN_YB401_NALM  Propagate a pulse in the Yb401-PM NALM cavity model.
+%   result = RUN_YB401_NALM(params, options) executes the CQEM/IP solver
+%   for the cavity described by PARAMS (see DEFAULT_YB401_PARAMS) and
+%   returns a struct containing the field evolution, pulse metrics and
+%   locking status.  Plotdata aggregates per-segment traces for visualisation
+%   routines compatible with the legacy scripts.
+%
+%   Key options (all optional):
+%       max_round_trips        - maximum number of cavity iterations (80)
+%       lock_window            - number of recent trips used for lock check (8)
+%       energy_tolerance       - relative energy variation threshold (5e-3)
+%       bandwidth_tolerance_nm - allowed variation of spectral width (1.5 nm)
+%       target_bandwidth_nm    - desired spectral width for convergence (20 nm)
+%       minimum_bandwidth_nm   - minimum acceptable width when declaring lock
+%       chirp_rms_limit        - optional limit on RMS chirp (THz)
+%       adaptive_gain          - enable simple gain tuning heuristic (true)
+%       gain_step_main         - main gain adjustment per trip (0.4 dB)
+%       gain_step_nalm         - NALM gain adjustment per trip (0.25 dB)
+%       gain_main_limits       - [min max] bounds for main gain (30 45 dB)
+%       gain_nalm_limits       - [min max] bounds for NALM gain (20 34 dB)
+%       collect_history        - store field/spectrum history (true)
+%       collect_final_traces   - gather per-segment traces for diagnostics (true)
+%       stop_on_lock           - terminate when lock criteria satisfied (true)
+%       live_monitor           - plot per-trip summary (false)
+%       verbose                - print status messages (true)
+%
+%   The function assumes all helper functions (IP_CQEM_FD, coupler, etc.)
+%   are available on the MATLAB path.
+
+if nargin < 1 || isempty(params)
+    params = default_yb401_params();
+end
+if nargin < 2
+    options = struct();
+end
+
+% ----------------------------- Options ---------------------------------
+opt = options;
+set_default = @(field, val) ( ~isfield(opt, field) || isempty(opt.(field)) );
+
+if set_default('max_round_trips', [])
+    opt.max_round_trips = 80;
+end
+if set_default('lock_window', [])
+    opt.lock_window = 8;
+end
+if set_default('energy_tolerance', [])
+    opt.energy_tolerance = 5e-3;          % relative variation
+end
+if set_default('bandwidth_tolerance_nm', [])
+    opt.bandwidth_tolerance_nm = 1.5;
+end
+if set_default('target_bandwidth_nm', [])
+    opt.target_bandwidth_nm = 20;
+end
+if set_default('minimum_bandwidth_nm', [])
+    opt.minimum_bandwidth_nm = 18;
+end
+if set_default('chirp_rms_limit', [])
+    opt.chirp_rms_limit = inf;
+end
+if set_default('adaptive_gain', [])
+    opt.adaptive_gain = true;
+end
+if set_default('gain_step_main', [])
+    opt.gain_step_main = 0.4;
+end
+if set_default('gain_step_nalm', [])
+    opt.gain_step_nalm = 0.25;
+end
+if set_default('gain_main_limits', [])
+    opt.gain_main_limits = [30 45];
+end
+if set_default('gain_nalm_limits', [])
+    opt.gain_nalm_limits = [20 34];
+end
+if set_default('collect_history', [])
+    opt.collect_history = true;
+end
+if set_default('collect_final_traces', [])
+    opt.collect_final_traces = true;
+end
+if set_default('stop_on_lock', [])
+    opt.stop_on_lock = true;
+end
+if set_default('live_monitor', [])
+    opt.live_monitor = false;
+end
+if set_default('verbose', [])
+    opt.verbose = true;
+end
+
+% ----------------------- Build cavity components -----------------------
+c = params.constants.c;
+lamda_pulse = params.pulse.lambda;
+fo = c/lamda_pulse;
+
+nt = params.grid.nt;
+T_window = params.grid.time_window;
+dt = T_window/nt;
+t = -T_window/2:dt:(T_window/2-dt);
+
+df = 1/(nt*dt);
+f = -(nt/2)*df:df:(nt/2-1)*df;
+
+base = struct();
+base.Aeff = params.fibre.Aeff;
+base.n2 = params.fibre.n2;
+base.gamma = 2*pi*base.n2/lamda_pulse/base.Aeff*1e4;
+base.alpha = log(10)*params.fibre.alpha_dB_per_m/10 * 1e3;  % km^-1
+base.betaw = [0 0 params.fibre.beta2 params.fibre.beta3];
+base.raman = double(params.fibre.include_raman);
+base.ssp = double(params.fibre.include_ssp);
+
+sections = params.sections;
+
+smf_link = base;    smf_link.L = sections.smf_link;
+smf_output = base;  smf_output.L = sections.smf_output;
+smf_pre = base;     smf_pre.L = sections.smf_pre;
+smf_post = base;    smf_post.L = sections.smf_post;
+smf_linear = base;  smf_linear.L = sections.smf_linear;
+
+amf_main = base;
+amf_main.L = sections.amf_main.L;
+amf_main.gssdB = sections.amf_main.gssdB;
+amf_main.PsatdBm = sections.amf_main.PsatdBm;
+amf_main.lamda_gain = lamda_pulse;
+amf_main.landa_bw = sections.amf_main.bandwidth_nm;
+amf_main.fc = fo;
+amf_main.fbw = c/(lamda_pulse)^2 * amf_main.landa_bw;
+
+amf_nalm = base;
+amf_nalm.L = sections.amf_nalm.L;
+amf_nalm.gssdB = sections.amf_nalm.gssdB;
+amf_nalm.PsatdBm = sections.amf_nalm.PsatdBm;
+amf_nalm.lamda_gain = lamda_pulse;
+amf_nalm.landa_bw = sections.amf_nalm.bandwidth_nm;
+amf_nalm.fc = fo;
+amf_nalm.fbw = c/(lamda_pulse)^2 * amf_nalm.landa_bw;
+
+cfbg = params.cfbg;
+cfbg.fc = fo;
+cfbg.beta2 = -cfbg.dispersion*(cfbg.lambda_c^2)/(2*pi*c);
+
+rho = params.couplers.rho;
+rho_out = params.couplers.rho_out;
+
+dz = params.grid.dz;
+tol = params.grid.tol;
+
+% ------------------------- Initial condition ---------------------------
+N2 = params.pulse.N2;
+tfwhm = params.pulse.tfwhm;
+P_peak = 2*N2*abs(base.betaw(3))/base.gamma/tfwhm^2;
+u0 = sqrt(P_peak) * sech(t/tfwhm);
+
+if isfield(params.pulse, 'random_seed')
+    randn('state', params.pulse.random_seed);
+end
+if isfield(params.pulse, 'noise_level') && params.pulse.noise_level > 0
+    u0 = (1 + params.pulse.noise_level*randn(1, nt)) .* u0;
+end
+
+if opt.verbose
+    fprintf('\nInput peak power (W)        : %6.3f\n', max(abs(u0).^2));
+    fprintf('Input pulse energy (pJ)     : %6.3f\n', dt*sum(abs(u0).^2));
+    fprintf('Target spectral width (nm)  : %.2f (min %.2f)\n', ...
+            opt.target_bandwidth_nm, opt.minimum_bandwidth_nm);
+end
+
+% --------------------------- Storage setup -----------------------------
+max_trips = opt.max_round_trips;
+u_history = [];
+spec_history = [];
+metrics_history(max_trips) = struct();
+gain_main_history = zeros(1, max_trips);
+gain_nalm_history = zeros(1, max_trips);
+
+if opt.collect_history
+    u_history = zeros(max_trips, nt);
+    spec_history = zeros(max_trips, nt);
+end
+
+lock_round = NaN;
+locked = false;
+
+if opt.live_monitor
+    monitor_fig = figure('Name', 'Yb401-PM NALM monitor'); %#ok<NASGU>
+end
+
+% Waitbar only when live monitoring requested to avoid GUI overhead
+if opt.live_monitor
+    h_wait = waitbar(0, 'Yb401-PM NALM simulation...');
+end
+
+u = u0;
+final_plots = struct();
+
+for ii = 1:max_trips
+    if opt.live_monitor
+        waitbar((ii-1)/max_trips, h_wait, ...
+            sprintf('Trip %d/%d', ii, max_trips));
+    end
+
+    store_traces = opt.collect_final_traces;
+
+    [u, ~, Plot_link] = IP_CQEM_FD(u, dt, dz, smf_link, fo, tol, store_traces, 0);
+    [u, ~, Plot_main_gain] = IP_CQEM_FD(u, dt, dz, amf_main, fo, tol, store_traces, 0);
+    [u, ~, Plot_output] = IP_CQEM_FD(u, dt, dz, smf_output, fo, tol, store_traces, 0);
+
+    [uf, ub] = coupler(u, 0, rho);
+
+    [uf, ~, ~] = IP_CQEM_FD(uf, dt, dz, smf_pre, fo, tol, store_traces, 0);
+    [uf, ~, ~] = IP_CQEM_FD(uf, dt, dz, amf_nalm, fo, tol, store_traces, 0);
+    [uf, ~, ~] = IP_CQEM_FD(uf, dt, dz, smf_post, fo, tol, store_traces, 0);
+
+    [ub, ~, ~] = IP_CQEM_FD(ub, dt, dz, smf_post, fo, tol, store_traces, 0);
+    [ub, ~, ~] = IP_CQEM_FD(ub, dt, dz, amf_nalm, fo, tol, store_traces, 0);
+    [ub, ~, ~] = IP_CQEM_FD(ub, dt, dz, smf_pre, fo, tol, store_traces, 0);
+
+    [~, ut] = coupler(ub, uf, rho);
+    u = ut;
+
+    [u, ~, Plot_pre] = IP_CQEM_FD(u, dt, dz, smf_pre, fo, tol, store_traces, 1);
+    [u, uout] = coupler(u, 0, rho_out);
+
+    [u, Plot_cfbg] = apply_cfbg(u, cfbg, fo, df, c);
+
+    metrics = compute_locking_metrics(uout, dt, f, fo, c);
+    metrics_history(ii) = metrics;
+    gain_main_history(ii) = amf_main.gssdB;
+    gain_nalm_history(ii) = amf_nalm.gssdB;
+
+    if opt.collect_history
+        u_history(ii, :) = uout;
+        spec_history(ii, :) = metrics.spectrum;
+    end
+
+    if opt.collect_final_traces
+        final_plots.Plot_link = Plot_link;
+        final_plots.Plot_main_gain = Plot_main_gain;
+        final_plots.Plot_output = Plot_output;
+        final_plots.ut = ut;
+        final_plots.Plot_pre = Plot_pre;
+        final_plots.uout = uout;
+        final_plots.Plot_cfbg = Plot_cfbg;
+    end
+
+    % ------------------------- Lock detection -------------------------
+    window = min(opt.lock_window, ii);
+    recent_metrics = metrics_history(ii-window+1:ii);
+    energy_vals = [recent_metrics.energy_pJ];
+    bandwidth_vals = [recent_metrics.spectral_width_nm];
+    chirp_vals = [recent_metrics.chirp_rms_THz];
+
+    energy_rel_var = max(abs(diff(energy_vals))) / max(energy_vals(end), eps);
+    bandwidth_span = max(bandwidth_vals) - min(bandwidth_vals);
+    mean_bandwidth = mean(bandwidth_vals);
+    max_chirp = max(chirp_vals);
+
+    if window == opt.lock_window && ...
+            energy_rel_var <= opt.energy_tolerance && ...
+            bandwidth_span <= opt.bandwidth_tolerance_nm && ...
+            mean_bandwidth >= opt.minimum_bandwidth_nm && ...
+            max_chirp <= opt.chirp_rms_limit
+        locked = true;
+        lock_round = ii;
+        if opt.verbose
+            fprintf('Lock detected at round trip %d: width = %.2f nm, energy %.3f pJ\n', ...
+                ii, metrics.spectral_width_nm, metrics.energy_pJ);
+        end
+        if opt.stop_on_lock
+            break;
+        end
+    end
+
+    % --------------------- Adaptive gain heuristics -------------------
+    if opt.adaptive_gain
+        if metrics.spectral_width_nm < opt.target_bandwidth_nm
+            amf_main.gssdB = min(amf_main.gssdB + opt.gain_step_main, opt.gain_main_limits(2));
+            amf_nalm.gssdB = min(amf_nalm.gssdB + 0.5*opt.gain_step_nalm, opt.gain_nalm_limits(2));
+        elseif metrics.spectral_width_nm > opt.target_bandwidth_nm + opt.bandwidth_tolerance_nm
+            amf_main.gssdB = max(amf_main.gssdB - opt.gain_step_main, opt.gain_main_limits(1));
+        end
+
+        if metrics.chirp_rms_THz > opt.chirp_rms_limit && isfinite(opt.chirp_rms_limit)
+            amf_nalm.gssdB = max(amf_nalm.gssdB - opt.gain_step_nalm, opt.gain_nalm_limits(1));
+        end
+    end
+
+    if opt.live_monitor
+        subplot(2,1,1);
+        plot(t, abs(uout).^2, 'r', t, abs(u0).^2, 'k:'); grid on;
+        xlabel('Time (ps)'); ylabel('|u|^2 (W)');
+        title(sprintf('Trip %d intensity', ii));
+
+        subplot(2,1,2);
+        plot(metrics.lambda_axis, metrics.spectrum, 'b'); grid on;
+        xlabel('Wavelength (nm)'); ylabel('Normalised spectrum');
+        title(sprintf('Bandwidth %.2f nm  Gain %.1f/%.1f dB', ...
+            metrics.spectral_width_nm, amf_main.gssdB, amf_nalm.gssdB));
+        drawnow;
+    end
+end
+
+if opt.live_monitor
+    close(h_wait);
+end
+
+if isnan(lock_round)
+    lock_round = max_trips;
+end
+
+% ----------------------- Assemble result struct ------------------------
+result = struct();
+result.u0 = u0;
+result.uout = uout;
+result.ut = ut;
+result.time = t;
+result.dt = dt;
+result.f = f;
+result.fo = fo;
+result.c = c;
+result.df = df;
+result.lambda = c./(f + fo);
+result.metrics_history = metrics_history(1:ii);
+result.gain_main_history = gain_main_history(1:ii);
+result.gain_nalm_history = gain_nalm_history(1:ii);
+result.locked = locked;
+result.lock_round = lock_round;
+result.round_trips_executed = ii;
+result.adaptive_gain_enabled = opt.adaptive_gain;
+result.options = opt;
+
+if opt.collect_history
+    result.u_history = u_history(1:ii, :);
+    result.spec_history = spec_history(1:ii, :);
+else
+    result.u_history = [];
+    result.spec_history = [];
+end
+
+% Store the final metrics for convenience
+result.final_metrics = metrics_history(ii);
+result.final_gains = struct('amf_main', amf_main.gssdB, ...
+                             'amf_nalm', amf_nalm.gssdB);
+
+% Compose Plotdata compatible with legacy visualisations
+if opt.collect_final_traces && ~isempty(fieldnames(final_plots))
+    ut_fft = repmat(abs(fftshift(fft(final_plots.ut))), 20, 1);
+    uout_fft = repmat(abs(fftshift(fft(final_plots.uout))), 20, 1);
+
+    Plotdata.ufft = [final_plots.Plot_link.ufft; ...
+                     final_plots.Plot_main_gain.ufft; ...
+                     final_plots.Plot_output.ufft; ...
+                     ut_fft; ...
+                     final_plots.Plot_pre.ufft; ...
+                     uout_fft; ...
+                     final_plots.Plot_cfbg.ufft];
+
+    ut_t = repmat(final_plots.ut, 20, 1);
+    uout_t = repmat(final_plots.uout, 20, 1);
+
+    Plotdata.u = [final_plots.Plot_link.u; ...
+                  final_plots.Plot_main_gain.u; ...
+                  final_plots.Plot_output.u; ...
+                  ut_t; ...
+                  final_plots.Plot_pre.u; ...
+                  uout_t; ...
+                  final_plots.Plot_cfbg.u];
+else
+    Plotdata = struct('ufft', [], 'u', []);
+end
+
+end

--- a/scan_yb401_nalm.m
+++ b/scan_yb401_nalm.m
@@ -1,0 +1,114 @@
+function scan_results = scan_yb401_nalm(base_params, base_options, sweep)
+%SCAN_YB401_NALM  Coarse parameter scan for the Yb401-PM NALM cavity.
+%   scan_results = SCAN_YB401_NALM(base_params, base_options, sweep)
+%   iterates over the provided parameter grids (coupler ratios, gain levels,
+%   initial pulse widths) and records the resulting bandwidth and lock status.
+%   It is intended to help locate parameter combinations that produce >20 nm
+%   spectra or stable soliton-like pulses.
+%
+%   The SWEEP struct may define the following vectors:
+%       rho_values           - NALM coupler ratios
+%       rho_out_values       - output coupler ratios
+%       gain_main_values     - main gain gssdB values
+%       gain_nalm_values     - NALM gain gssdB values
+%       tfwhm_values         - input pulse widths (ps)
+%       N2_values            - soliton order squared values
+%       max_round_trips      - override for per-simulation trip count
+%
+%   Results are returned in scan_results.results (struct array) and the best
+%   candidate (largest spectral width that satisfies the lock criterion) is
+%   returned as scan_results.best.  Each entry includes the final metrics,
+%   lock status, and updated parameter set.
+
+if nargin < 1 || isempty(base_params)
+    base_params = default_yb401_params();
+end
+if nargin < 2
+    base_options = struct();
+end
+if nargin < 3
+    sweep = struct();
+end
+
+% Default sweeps
+if ~isfield(sweep, 'rho_values') || isempty(sweep.rho_values)
+    sweep.rho_values = 0.4:0.05:0.55;
+end
+if ~isfield(sweep, 'rho_out_values') || isempty(sweep.rho_out_values)
+    sweep.rho_out_values = 0.2:0.05:0.3;
+end
+if ~isfield(sweep, 'gain_main_values') || isempty(sweep.gain_main_values)
+    sweep.gain_main_values = 34:2:40;
+end
+if ~isfield(sweep, 'gain_nalm_values') || isempty(sweep.gain_nalm_values)
+    sweep.gain_nalm_values = 24:2:30;
+end
+if ~isfield(sweep, 'tfwhm_values') || isempty(sweep.tfwhm_values)
+    sweep.tfwhm_values = [3.0 3.5 4.0];
+end
+if ~isfield(sweep, 'N2_values') || isempty(sweep.N2_values)
+    sweep.N2_values = [1.2^2 1.35^2 1.5^2];
+end
+if ~isfield(sweep, 'max_round_trips') || isempty(sweep.max_round_trips)
+    sweep.max_round_trips = 80;
+end
+
+local_opt = base_options;
+local_opt.collect_history = false;
+local_opt.collect_final_traces = false;
+local_opt.live_monitor = false;
+local_opt.verbose = false;
+local_opt.max_round_trips = sweep.max_round_trips;
+
+idx = 0;
+results = struct([]);
+
+for rho = sweep.rho_values
+    for rho_out = sweep.rho_out_values
+        for g_main = sweep.gain_main_values
+            for g_nalm = sweep.gain_nalm_values
+                for tfwhm = sweep.tfwhm_values
+                    for N2 = sweep.N2_values
+                        idx = idx + 1;
+                        params = base_params;
+                        params.couplers.rho = rho;
+                        params.couplers.rho_out = rho_out;
+                        params.sections.amf_main.gssdB = g_main;
+                        params.sections.amf_nalm.gssdB = g_nalm;
+                        params.pulse.tfwhm = tfwhm;
+                        params.pulse.N2 = N2;
+
+                        [sim_result, ~] = run_yb401_nalm(params, local_opt);
+                        final_metrics = sim_result.final_metrics;
+
+                        results(idx).params = params; %#ok<AGROW>
+                        results(idx).result = sim_result; %#ok<AGROW>
+                        results(idx).spectral_width_nm = final_metrics.spectral_width_nm; %#ok<AGROW>
+                        results(idx).locked = sim_result.locked; %#ok<AGROW>
+                        results(idx).round_trips = sim_result.round_trips_executed; %#ok<AGROW>
+                    end
+                end
+            end
+        end
+    end
+end
+
+if isempty(results)
+    scan_results = struct('results', [], 'best', []);
+    return;
+end
+
+% Identify best locked candidate; if none locked, pick widest spectrum.
+locked_idx = find([results.locked]);
+if ~isempty(locked_idx)
+    [~, rel_idx] = max([results(locked_idx).spectral_width_nm]);
+    best_idx = locked_idx(rel_idx);
+else
+    [~, best_idx] = max([results.spectral_width_nm]);
+end
+
+scan_results = struct();
+scan_results.results = results;
+scan_results.best = results(best_idx);
+
+end

--- a/simulate_nalm_yb401_pm.m
+++ b/simulate_nalm_yb401_pm.m
@@ -1,0 +1,168 @@
+% simulate_nalm_yb401_pm.m
+% -------------------------------------------------------------------------
+% High-level driver for the Yb401-PM based NALM fibre laser simulation.
+% The script first runs the cavity with adaptive gain control aiming for a
+% 20 nm output bandwidth.  If the heuristic does not converge, a coarse
+% parameter scan is launched automatically to locate a more favourable
+% configuration before re-running the detailed simulation for diagnostics.
+% -------------------------------------------------------------------------
+
+clear; clc;
+
+%% ------------------------- Base parameters -----------------------------
+params = default_yb401_params();
+
+% Example tweaks: uncomment to bias the initial run
+% params.sections.amf_main.gssdB = 40;
+% params.sections.amf_nalm.gssdB = 28;
+% params.pulse.tfwhm = 3.2;
+
+%% --------------------------- Solver options ----------------------------
+options = struct();
+options.max_round_trips = 120;
+options.lock_window = 10;
+options.energy_tolerance = 3e-3;
+options.bandwidth_tolerance_nm = 1.2;
+options.target_bandwidth_nm = 20;
+options.minimum_bandwidth_nm = 18.5;
+options.chirp_rms_limit = 2.5;
+options.adaptive_gain = true;
+options.gain_step_main = 0.5;
+options.gain_step_nalm = 0.3;
+options.collect_history = true;
+options.collect_final_traces = true;
+options.stop_on_lock = true;
+options.live_monitor = false;       % set true for per-trip plots
+options.verbose = true;
+
+%% -------------------------- Initial simulation ------------------------
+[result, Plotdata] = run_yb401_nalm(params, options);
+
+if ~result.locked
+    fprintf('\nInitial configuration did not reach the target bandwidth.\n');
+    fprintf('Launching coarse parameter scan to search for broader spectra...\n');
+
+    sweep = struct();
+    sweep.max_round_trips = 70;
+    sweep.rho_values = 0.35:0.05:0.6;
+    sweep.rho_out_values = 0.2:0.05:0.35;
+    sweep.gain_main_values = 34:2:42;
+    sweep.gain_nalm_values = 24:2:32;
+    sweep.tfwhm_values = [3.0 3.5 4.0];
+    sweep.N2_values = [1.2^2 1.35^2 1.5^2];
+
+    scan_results = scan_yb401_nalm(params, options, sweep);
+    best = scan_results.best;
+
+    fprintf('Best candidate from scan: rho=%.2f, rho_out=%.2f, Gmain=%.1f dB, Gnalm=%.1f dB, BW=%.2f nm\n', ...
+        best.params.couplers.rho, best.params.couplers.rho_out, ...
+        best.params.sections.amf_main.gssdB, best.params.sections.amf_nalm.gssdB, ...
+        best.spectral_width_nm);
+
+    params = best.params;
+    options.max_round_trips = 150;
+    options.live_monitor = false;
+    [result, Plotdata] = run_yb401_nalm(params, options);
+end
+
+%% --------------------------- Diagnostics -------------------------------
+metrics = result.final_metrics;
+time = result.time;
+dt = result.dt;
+f = result.f;
+fo = result.fo;
+c = result.c;
+u0 = result.u0;
+uout = result.uout;
+lambda = result.lambda;
+
+fprintf('\nFinal gains: main = %.2f dB, NALM = %.2f dB\n', ...
+    result.final_gains.amf_main, result.final_gains.amf_nalm);
+fprintf('Output bandwidth: %.2f nm\n', metrics.spectral_width_nm);
+fprintf('Output energy: %.3f pJ\n', metrics.energy_pJ);
+
+% Time-domain comparison
+figure(1); clf;
+plot(time, abs(u0).^2, 'b-', 'LineWidth', 1.1); hold on;
+plot(time, abs(uout).^2, 'r-', 'LineWidth', 1.2); grid on; hold off;
+xlabel('Time (ps)'); ylabel('|u|^2 (W)');
+legend('Seed', 'Output');
+title('Seed vs. output intensity');
+
+% Spectrum
+spec = fftshift(abs(fft(uout)).^2);
+specnorm = spec ./ (lambda.^2);
+specnorm = specnorm / max(specnorm);
+figure(2); clf;
+plot(lambda, specnorm, 'LineWidth', 1.2); grid on;
+xlabel('Wavelength (nm)'); ylabel('Normalised spectrum (a.u.)');
+title(sprintf('Output spectrum (%.2f nm FWHM)', metrics.spectral_width_nm));
+
+% Temporal evolution across round trips
+if ~isempty(result.u_history)
+    figure(3); clf;
+    surf(time, 1:size(result.u_history,1), abs(result.u_history).^2);
+    shading interp; axis tight; colorbar;
+    ylabel('Round trip'); xlabel('Time (ps)'); zlabel('|u|^2 (W)');
+    title('Temporal evolution across round trips');
+    view(0, 90);
+end
+
+% Spectral evolution
+if ~isempty(result.spec_history)
+    figure(4); clf;
+    surf(lambda, 1:size(result.spec_history,1), result.spec_history);
+    shading interp; axis tight; colorbar;
+    ylabel('Round trip'); xlabel('Wavelength (nm)');
+    zlabel('Normalised spectrum (a.u.)');
+    title('Spectral evolution across round trips');
+    view(0, 90);
+end
+
+% Output chirp analysis
+phase_out = unwrap(angle(uout));
+chirp = -diff(phase_out)/(2*pi*dt);
+intensity_out = abs(uout).^2;
+[width_samples, ~, ~] = fwhm(intensity_out);
+figure(5); clf;
+[ax, p1, p2] = plotyy(time, intensity_out, time(1:end-1), chirp, 'plot', 'plot'); %#ok<ASGLU>
+set(p1, 'LineWidth', 1.4);
+set(p2, 'LineWidth', 1.2, 'LineStyle', '--', 'Color', [0.2 0.2 0.7]);
+xlabel(sprintf('Time (ps)   FWHM %.2f ps', width_samples*dt));
+ylabel(ax(1), '|u|^2 (W)'); ylabel(ax(2), 'Chirp (THz)');
+axis(ax(1), 'tight'); axis(ax(2), 'tight'); grid on;
+title('Output intensity and instantaneous frequency');
+
+% Final round-trip diagnostics using Plotdata
+if ~isempty(Plotdata.ufft)
+    figure(6); clf;
+    surf(lambda, 1:size(Plotdata.ufft,1), ...
+         (abs(Plotdata.ufft').^2) ./ (lambda'*ones(1, size(Plotdata.ufft,1))).^2);
+    shading interp; axis tight; colorbar;
+    xlabel('Wavelength (nm)'); ylabel('Segment index');
+    zlabel('Normalised spectral power');
+    title('Segment-resolved spectral evolution (final trip)');
+    view(0, 90);
+
+    figure(7); clf;
+    surf(time, 1:size(Plotdata.u,1), abs(Plotdata.u).^2);
+    shading interp; axis tight; colorbar;
+    xlabel('Time (ps)'); ylabel('Segment index');
+    zlabel('|u|^2 (W)');
+    title('Segment-resolved temporal evolution (final trip)');
+    view(0, 90);
+end
+
+%% ------------------------- Summary report ------------------------------
+if result.locked
+    fprintf('\nLock achieved at trip %d with %.2f nm bandwidth.\n', ...
+        result.lock_round, metrics.spectral_width_nm);
+else
+    fprintf('\nNo lock detected within %d round trips.\n', result.round_trips_executed);
+end
+
+fprintf('Gain history (main/NALM) dB: %.1f -> %.1f / %.1f -> %.1f\n', ...
+    result.gain_main_history(1), result.gain_main_history(end), ...
+    result.gain_nalm_history(1), result.gain_nalm_history(end));
+
+fprintf('\nUse scan_yb401_nalm or adjust params/options to explore further.\n');


### PR DESCRIPTION
## Summary
- refactor the Yb401-PM simulation into reusable defaults and a run helper that records pulse metrics and adaptive gain history
- add spectral-width measurement, lock-detection heuristics, and optional coarse parameter scanning to reach 20 nm bandwidth targets
- update the main driver script to use the new utilities, report lock status, and regenerate diagnostic plots from the recorded histories

## Testing
- not run (MATLAB environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68fb3862fa68832486334cc5b818f66d